### PR TITLE
Provide alternative method of defining traits without `provides` magic

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ class Lion
 end
 ```
 
+Alternatively a trait can be created with `Fabrik::Trait.build` method:
+
+```ruby
+Lion = Fabrik::Trait.build do
+  def mother; :lioness end
+  def father; :lion end
+end
+```
+
 A class uses traits by extending `Fabrik::Composer` and composing the traits.
 
 ```ruby
@@ -81,6 +90,27 @@ tigon = Tigon.new
 tigon.roar    # => :roar!
 tigon.mother  # => :lioness
 tigon.father  # => :tiger
+```
+
+Traits can be composed from other traits in the same way:
+
+```ruby
+class TigonTrait
+  extend Fabrik::Trait
+  compose Panthera,
+          Tiger[exclude: :mother],
+          Lion[exclude: :father]
+end
+```
+
+Alternatively `.build` method can be used:
+
+```ruby
+TigonTrait = Fabrik::Trait.build(Panthera,
+                                 Tiger[exclude: :mother],
+                                 Lion[exclude: :father]) do
+  def scratch; :scratched end
+end
 ```
 
 View the specs for further examples, including composable traits and traits

--- a/lib/fabrik/trait.rb
+++ b/lib/fabrik/trait.rb
@@ -9,6 +9,14 @@ module Fabrik
     extend Forwardable
     def_delegators :own, :instance_methods, :send
 
+    def self.build(*args, &blk)
+      Class.new do
+        extend Trait
+        compose(*args) if args.count > 0
+        provides(&blk) if blk
+      end
+    end
+
     def methods(opts = {})
       provides_from(own, *own.instance_methods)
       dictionary.method_map(opts)

--- a/spec/fabrik/trait_spec.rb
+++ b/spec/fabrik/trait_spec.rb
@@ -14,6 +14,39 @@ describe Fabrik::Trait do
     Class.new.extend(Fabrik::Trait)
   end
 
+  describe '::build' do
+    it 'allows to build a trait class' do
+      trait_klass = Fabrik::Trait.build do
+        def a; end
+      end
+
+      expect(trait_klass.own.instance_methods).to include(:a)
+    end
+
+    it 'allows to compose different traits' do
+      trait_a = Fabrik::Trait.build do
+        def a; :a end
+        def c; :c end
+      end
+
+      trait_b = Fabrik::Trait.build do
+        def a; :ab end
+        def b; :bc end
+      end
+
+      trait_c = Fabrik::Trait.build do
+        def b; :cd end
+      end
+
+      trait_klass = Fabrik::Trait.build(trait_c, trait_b[exclude: :b], trait_a[exclude: :a])
+      klass = Class.new.extend(Fabrik::Composer)
+      klass.compose(trait_klass)
+      instance = klass.new
+
+      expect([instance.a, instance.b, instance.c]).to eq([:ab, :cd, :c])
+    end
+  end
+
   describe '.methods' do
     it 'returns the method map from the dictionary' do
       opts = {}


### PR DESCRIPTION
Hi @joecorcoran, it is related to our discussion in #1. I find this syntax of creating traits more concise and nice. And this one provides it only as an alternative way of creating them, more or less like a shortcut. Your thoughts?
